### PR TITLE
refactoring; documentation; minor fixes

### DIFF
--- a/src/components/Block.tsx
+++ b/src/components/Block.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { TouchableOpacity, Text } from 'react-native';
+import Ionicon from '@expo/vector-icons/Ionicons';
+import { BlockContainer } from './BlockContainer';
+
+interface BlockProps {
+  // Name of the block
+  title: string;
+
+  // Handler for when the main block body is pressed
+  onPress?: () => void;
+
+  // Handler for when the options ellipsis are pressed
+  onOptionsPress?: () => void;
+}
+
+const Block: React.FC<BlockProps> = ({ title, onPress, onOptionsPress }) => {
+  return (
+    <BlockContainer>
+      <TouchableOpacity
+        accessibilityRole="button"
+        className="flex h-full flex-1 flex-row items-center p-1"
+        onPress={onPress}
+        hitSlop={{ top: 20, bottom: 20, left: 20 }}
+      >
+        <Text className="text-base font-medium">{title}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        className="flex h-full flex-row items-center justify-center p-1"
+        hitSlop={{ top: 20, bottom: 20, right: 20 }}
+        onPress={onOptionsPress}
+      >
+        <Ionicon name="ellipsis-horizontal" size={16} />
+      </TouchableOpacity>
+    </BlockContainer>
+  );
+};
+
+export default Block;

--- a/src/components/BreadcrumbsHeader.tsx
+++ b/src/components/BreadcrumbsHeader.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { NavigatorParamList } from '../screens/DrawerNavigator';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import useSelectedWorkout from '../hooks/useSelectedWorkout';
+import useBreadcrumbHistory from '../hooks/useBreadcrumbHistory';
 
 interface BreadcrumbsHeaderProps {
   navigation: NativeStackNavigationProp<NavigatorParamList, keyof NavigatorParamList, undefined>;
@@ -11,7 +11,7 @@ interface BreadcrumbsHeaderProps {
 }
 
 const BreadcrumbsHeader: React.FC<BreadcrumbsHeaderProps> = ({ route, navigation }) => {
-  const [workout, exercise] = useSelectedWorkout((state) => [state.workout, state.exercise]);
+  const [workout, exercise] = useBreadcrumbHistory((state) => [state.workout, state.exercise]);
 
   const MyWorkoutsLink = useMemo(() => {
     const shouldAbbreviateName = route.name === 'EditExercisePage';

--- a/src/components/ExerciseBlock.tsx
+++ b/src/components/ExerciseBlock.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { Text, TouchableOpacity } from 'react-native';
 import ExerciseSearchBar from './ExerciseSearchBar';
-import { Exercise } from '../types/Exercise';
-import { BlockContainer } from './BlockContainer';
-import Ionicon from '@expo/vector-icons/Ionicons';
+import { Exercise } from '../types';
+import Block from './Block';
 
-interface ExerciseBlockProps {
+interface ExerciseCardProps {
   editing: string | undefined;
   exercise: Exercise;
   update: (id: string, e: Exercise) => void;
   onPress: (w: Exercise) => void;
 }
 
-const ExerciseBlock: React.FC<ExerciseBlockProps> = ({ editing, exercise, update, onPress }) => {
+const ExerciseBlock: React.FC<ExerciseCardProps> = ({ editing, exercise, update, onPress }) => {
   if (editing === exercise.name) {
     return (
       <ExerciseSearchBar
@@ -26,25 +24,12 @@ const ExerciseBlock: React.FC<ExerciseBlockProps> = ({ editing, exercise, update
     );
   }
   return (
-    <BlockContainer>
-      <TouchableOpacity
-        accessibilityRole="button"
-        className="h-full flex-1 p-1"
-        onPress={() => {
-          onPress(exercise);
-        }}
-        hitSlop={{ top: 20, left: 20, bottom: 20 }}
-      >
-        <Text className="text-base font-medium">{exercise.name}</Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        className="flex h-full flex-row items-center justify-center p-1"
-        hitSlop={{ top: 20, bottom: 20, right: 20 }}
-      >
-        <Ionicon name="ellipsis-horizontal" size={16} />
-      </TouchableOpacity>
-    </BlockContainer>
+    <Block
+      title={exercise.name}
+      onPress={() => {
+        onPress(exercise);
+      }}
+    />
   );
 };
 

--- a/src/components/ExerciseSearchBar.tsx
+++ b/src/components/ExerciseSearchBar.tsx
@@ -47,7 +47,7 @@ const ExerciseSearchBar: React.FC<ExerciseSearchBarProps> = ({ onSelectExercise 
   };
 
   return (
-    <View className="h-full w-screen items-center bg-slate-50 ">
+    <View className="h-full w-screen items-center bg-white">
       <View className="mt-7 h-12  w-11/12 rounded-t  border-x border-t border-slate-200 bg-slate-50">
         <TextInput
           accessibilityLabel="Exercise Search Text Field "

--- a/src/components/SetCard.tsx
+++ b/src/components/SetCard.tsx
@@ -5,13 +5,13 @@ import Card from './Card';
 interface SetCardProps {
   reps: string;
   setReps: (val: string) => void;
-  pre: string;
-  setPre: (val: string) => void;
+  rpe: string;
+  setRpe: (val: string) => void;
   orm: string;
   setOrm: (val: string) => void;
 }
 
-const SetCard: React.FC<SetCardProps> = ({ reps, setReps, pre, setPre, orm, setOrm }) => {
+const SetCard: React.FC<SetCardProps> = ({ reps, setReps, rpe, setRpe, orm, setOrm }) => {
   return (
     <Card title="Set">
       <TextInput
@@ -25,12 +25,12 @@ const SetCard: React.FC<SetCardProps> = ({ reps, setReps, pre, setPre, orm, setO
       />
       <TextInput
         accessibilityLabel="Text input Input"
-        accessibilityHint="Input to change pre in set"
+        accessibilityHint="Input to change rpe in set"
         className="w-[60px] rounded border p-1"
         returnKeyType="next"
-        placeholder="PRE"
-        value={pre}
-        onChangeText={setPre}
+        placeholder="RPE"
+        value={rpe}
+        onChangeText={setRpe}
       />
       <TextInput
         accessibilityLabel="Text input Input"

--- a/src/components/WorkoutBlock.tsx
+++ b/src/components/WorkoutBlock.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { Text, TextInput, TouchableOpacity } from 'react-native';
+import { TextInput } from 'react-native';
 import DoneButton from './DoneButton';
-import Ionicon from '@expo/vector-icons/Ionicons';
-import { EditableWorkout } from '../types/EditableWorkout';
+import { EditableWorkout } from '../types';
+import Block from './Block';
 import { BlockContainer } from './BlockContainer';
 
 interface WorkoutBlockProps {
@@ -32,23 +32,12 @@ const WorkoutBlock: React.FC<WorkoutBlockProps> = ({ editing, workout, updateNam
   }
 
   return (
-    <BlockContainer>
-      <TouchableOpacity
-        accessibilityRole="button"
-        className="flex h-full flex-1 flex-row items-center p-1"
-        onPress={() => onPress(workout)}
-        hitSlop={{ top: 20, bottom: 20, left: 20 }}
-      >
-        <Text className="text-base font-medium">{name}</Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        className="flex h-full flex-row items-center justify-center p-1"
-        hitSlop={{ top: 20, bottom: 20, right: 20 }}
-      >
-        <Ionicon name="ellipsis-horizontal" size={16} />
-      </TouchableOpacity>
-    </BlockContainer>
+    <Block
+      title={name}
+      onPress={() => {
+        onPress(workout);
+      }}
+    />
   );
 };
 

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,3 @@
+export class DuplicateExerciseError extends Error {}
+export class ExerciseNotFoundError extends Error {}
+export class UnauthenticatedError extends Error {}

--- a/src/hooks/useBreadcrumbHistory.ts
+++ b/src/hooks/useBreadcrumbHistory.ts
@@ -1,20 +1,19 @@
 import { create, UseBoundStore, StoreApi } from 'zustand';
-import { EditableWorkout } from '../types/EditableWorkout';
-import { Exercise } from '../types/Exercise';
+import { EditableWorkout, Exercise } from '../types';
 
-interface SelectedWorkoutState {
+interface BreadcrumbHistoryState {
   workout: EditableWorkout | undefined;
   setWorkout: (w: EditableWorkout | undefined) => void;
   exercise: Exercise | undefined;
   setExercise: (e: Exercise | undefined) => void;
 }
 
-const useSelectedWorkout: UseBoundStore<StoreApi<SelectedWorkoutState>> =
-  create<SelectedWorkoutState>()((set) => ({
+const useBreadcrumbHistory: UseBoundStore<StoreApi<BreadcrumbHistoryState>> =
+  create<BreadcrumbHistoryState>()((set) => ({
     workout: undefined,
     setWorkout: (w) => set({ workout: w }),
     exercise: undefined,
     setExercise: (e) => set({ exercise: e }),
   }));
 
-export default useSelectedWorkout;
+export default useBreadcrumbHistory;

--- a/src/hooks/useEditableWorkout.tsx
+++ b/src/hooks/useEditableWorkout.tsx
@@ -1,20 +1,26 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
-import { Session, User } from '@supabase/supabase-js';
-import { EditableWorkout } from '../types/EditableWorkout';
-import { Exercise } from '../types/Exercise';
+import { EditableWorkout } from '../types/';
+import { getEditableWorkout } from '../utils/workouts';
 
-export const useEditableWorkout = (id) => {
-  if (id === null || id === undefined) return {};
+/**
+ * Hooks in to a specific EditableWorkout and gets data
+ * either with async fetch or realtime listener
+ * @param workoutId Id of the EditableWorkout
+ * @param useRealtime Set to true if you want to create a realtime listener for this workout
+ * @returns `{workout, fetch, listening}`
+ */
+export const useEditableWorkout = (workoutId: string | undefined, useRealtime = false) => {
+  if (workoutId === null || workoutId === undefined) return {};
   const [listening, setListening] = useState<boolean>(false);
-  const [workout, setWorkout] = useState<EditableWorkout>({ id });
+  const [workout, setWorkout] = useState<EditableWorkout>({ id: workoutId });
 
   const listen = () => {
     const workoutChannel = supabase.channel('workout-channel');
 
     workoutChannel.on(
       'postgres_changes',
-      { event: '*', schema: 'public', table: 'workouts', filter: `id=eq.${id}` },
+      { event: '*', schema: 'public', table: 'workouts', filter: `id=eq.${workoutId}` },
       (payload) => {
         setWorkout(payload.new as EditableWorkout);
       }
@@ -34,9 +40,7 @@ export const useEditableWorkout = (id) => {
 
   const fetch = async () => {
     try {
-      const { data, error } = await supabase.from('workouts').select('*').eq('id', id).single();
-      if (error) throw error;
-
+      const data = await getEditableWorkout(workoutId);
       setWorkout(data);
     } catch (error) {
       console.error(error);
@@ -45,127 +49,11 @@ export const useEditableWorkout = (id) => {
 
   useEffect(() => {
     fetch();
-    const unsubscribe = listen();
-    return unsubscribe;
-  }, [id]);
-
-  return { workout, listening };
-};
-
-export const createEditableWorkout = async (
-  session: Session | null
-): Promise<EditableWorkout | undefined> => {
-  if (session === undefined || session === null) return undefined;
-
-  const user: User = session.user;
-
-  try {
-    const { data, error } = await supabase
-      .from('workouts')
-      .insert({ name: '', created_by: user.id })
-      .select(`id`)
-      .single();
-    if (error) throw error;
-
-    return data as EditableWorkout;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-export const deleteEditableWorkout = async (workoutId: string) => {
-  try {
-    const { error } = await supabase.from('workouts').delete().eq('id', workoutId);
-    if (error) throw error;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-export const updateEditableWorkout = async (payload: EditableWorkout) => {
-  try {
-    const { error } = await supabase.from('workouts').update(payload).eq('id', payload.id);
-    if (error) throw error;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-export const getExercisesInWorkout = async (workoutId: string): Promise<Array<Exercise>> => {
-  try {
-    const { error, data } = await supabase
-      .from('workouts')
-      .select('exercises')
-      .eq('id', workoutId)
-      .single();
-
-    if (error) throw error;
-
-    const exercises: Array<Exercise> = data?.exercises;
-    return exercises;
-  } catch (error) {
-    console.error(error);
-  }
-  return [];
-};
-
-const insertOrUpdateExercise: (id: string, e: Exercise, es: Array<Exercise>) => Array<Exercise> = (
-  identifier,
-  exercise,
-  exercises
-) => {
-  const shouldCheckForDuplicates = identifier !== exercise.name;
-
-  if (shouldCheckForDuplicates) {
-    const elem = exercises.find((e) => e.name === exercise.name);
-    if (elem) throw 'Cannot add duplicate exercise';
-  }
-
-  let found = false;
-  for (let i = 0; i < exercises.length; i++) {
-    if (exercises[i].name === identifier) {
-      exercises[i] = exercise;
-      found = true;
+    if (useRealtime) {
+      const unsubscribe = listen();
+      return unsubscribe;
     }
-  }
+  }, [workoutId, useRealtime]);
 
-  if (!found) exercises.push(exercise);
-
-  return exercises;
-};
-
-export const getExerciseInWorkout = async (exerciseName: string, workoutId: string) => {
-  const exercises: Array<Exercise> = await getExercisesInWorkout(workoutId);
-
-  for (let i = 0; i < exercises.length; i++) {
-    if (exercises[i].name === exerciseName) {
-      return exercises[i];
-    }
-  }
-
-  console.error(`Cannot find exercise in current workout`);
-  return undefined;
-};
-
-/**
- *
- * @param identifier name of exercise before change, used to find the current one in supabase
- * @param exercise
- * @param workout
- */
-export const updateExerciseInWorkout = async (
-  identifier: string,
-  exercise: Exercise,
-  workoutId: string
-) => {
-  let exercises: Array<Exercise> = await getExercisesInWorkout(workoutId);
-
-  exercises = insertOrUpdateExercise(identifier, exercise, exercises);
-
-  try {
-    const { error } = await supabase.from('workouts').update({ exercises }).eq('id', workoutId);
-    if (error) throw error;
-  } catch (error) {
-    console.error(error);
-  }
+  return { workout, fetch, listening };
 };

--- a/src/screens/EditExercise/EditExercisePage.tsx
+++ b/src/screens/EditExercise/EditExercisePage.tsx
@@ -6,17 +6,11 @@ import DraggableFlatList, { ScaleDecorator } from 'react-native-draggable-flatli
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import AddButton from '../../components/AddButton';
 import SetCard from '../../components/SetCard';
-import { getExerciseInWorkout, updateExerciseInWorkout } from '../../hooks/useEditableWorkout';
+import { getExerciseInWorkout, updateExerciseInWorkout } from '../../utils/workouts';
 import { NavigatorParamList } from '../DrawerNavigator';
+import { Set } from '../../types';
 
 type EditExercisePageProps = NativeStackScreenProps<NavigatorParamList, 'EditExercisePage'>;
-
-export type Set = {
-  key: number;
-  reps: string;
-  pre: string;
-  orm: string;
-};
 
 // TODO: Append rests or sets, not just sets
 const EditExercisePage: React.FC<EditExercisePageProps> = ({ route }) => {
@@ -35,17 +29,17 @@ const EditExercisePage: React.FC<EditExercisePageProps> = ({ route }) => {
     });
 
     setSets(_sets);
-    updateExerciseInWorkout(exerciseName, { name: exerciseName, sets: _sets }, workoutId);
+    updateExerciseInWorkout({ name: exerciseName, sets: _sets }, workoutId);
   };
 
   const appendEmptySet = () => {
-    setSets([...sets, { key: sets.length, reps: '', pre: '', orm: '' }]);
+    setSets([...sets, { key: sets.length, reps: '', rpe: '', orm: '' }]);
     // Doesn't update Supabase with empty sets
   };
 
   const reorderSets = (reorder: Set[]) => {
     setSets(reorder);
-    updateExerciseInWorkout(exerciseName, { name: exerciseName, sets: reorder }, workoutId);
+    updateExerciseInWorkout({ name: exerciseName, sets: reorder }, workoutId);
   };
 
   useEffect(() => {
@@ -65,8 +59,8 @@ const EditExercisePage: React.FC<EditExercisePageProps> = ({ route }) => {
             <SetCard
               reps={item.reps}
               setReps={(val) => updateSet(item.key, 'reps', val)}
-              pre={item.pre}
-              setPre={(val) => updateSet(item.key, 'pre', val)}
+              rpe={item.rpe}
+              setRpe={(val) => updateSet(item.key, 'rpe', val)}
               orm={item.orm}
               setOrm={(val) => updateSet(item.key, 'orm', val)}
             />
@@ -79,7 +73,7 @@ const EditExercisePage: React.FC<EditExercisePageProps> = ({ route }) => {
   return (
     <>
       <TouchableWithoutFeedback accessibilityRole="button" onPress={Keyboard.dismiss}>
-        <View className="h-full p-10 px-5">
+        <View className="h-full bg-white p-10 px-5">
           <DraggableFlatList
             data={sets}
             onDragEnd={({ data }) => reorderSets(data)}

--- a/src/screens/EditWorkout/EditWorkoutPage.tsx
+++ b/src/screens/EditWorkout/EditWorkoutPage.tsx
@@ -3,25 +3,43 @@ import React, { useState } from 'react';
 import { FlatList, KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
 import AddButton from '../../components/AddButton';
 import { NavigatorParamList } from '../DrawerNavigator';
-import { Exercise, PLACEHOLDER_EXERCISE_NAME } from '../../types/Exercise';
+import { Exercise, PLACEHOLDER_EXERCISE_NAME } from '../../types/';
 import ExerciseBlock from '../../components/ExerciseBlock';
-import { updateExerciseInWorkout, useEditableWorkout } from '../../hooks/useEditableWorkout';
-import useSelectedWorkout from '../../hooks/useSelectedWorkout';
+import { useEditableWorkout } from '../../hooks/useEditableWorkout';
+import {
+  insertExerciseIntoWorkout,
+  updateExerciseInWorkout,
+  deleteExerciseInWorkout,
+} from '../../utils/workouts';
+import useBreadcrumbHistory from '../../hooks/useBreadcrumbHistory';
 
 type EditWorkoutPageProps = NativeStackScreenProps<NavigatorParamList, 'EditWorkoutPage'>;
 
 const EditWorkoutPage: React.FC<EditWorkoutPageProps> = ({ navigation }) => {
-  const [selectedWorkout, setSelectedExercise] = useSelectedWorkout((state) => [
+  const [selectedWorkout, setSelectedExercise] = useBreadcrumbHistory((state) => [
     state.workout,
     state.setExercise,
   ]);
-  const { workout } = useEditableWorkout(selectedWorkout?.id);
+  const { workout } = useEditableWorkout(selectedWorkout?.id, true);
   const [editingExercise, setEditingExercise] = useState<string | undefined>(undefined);
 
-  const updateExercise = (identifier: string, exercise: Exercise) => {
+  /**
+   * Update an exercise or insert one if just created, alert if an error
+   * We need to take in the `currentName` param to see if it's a placeholder or not
+   * @param currentName
+   * @param exercise
+   */
+  const updateOrInsertExercise = async (currentName: string, exercise: Exercise) => {
     if (workout) {
       try {
-        updateExerciseInWorkout(identifier, exercise, workout.id);
+        // If currentName is the placeholder, we need to delete the placeholder and
+        // then insert the new exercise with the selected name
+        if (currentName === PLACEHOLDER_EXERCISE_NAME) {
+          await deleteExerciseInWorkout(PLACEHOLDER_EXERCISE_NAME, workout.id);
+          await insertExerciseIntoWorkout(exercise.name, workout.id);
+        } else {
+          await updateExerciseInWorkout(exercise, workout.id);
+        }
       } catch (error) {
         console.error(error);
         alert(error.message);
@@ -31,12 +49,13 @@ const EditWorkoutPage: React.FC<EditWorkoutPageProps> = ({ navigation }) => {
 
   const addExerciseBlock = async () => {
     if (selectedWorkout) {
-      await updateExerciseInWorkout(
-        PLACEHOLDER_EXERCISE_NAME,
-        { name: PLACEHOLDER_EXERCISE_NAME, sets: [] },
-        selectedWorkout.id
-      );
-      setEditingExercise(PLACEHOLDER_EXERCISE_NAME);
+      try {
+        insertExerciseIntoWorkout(PLACEHOLDER_EXERCISE_NAME, selectedWorkout.id);
+        setEditingExercise(PLACEHOLDER_EXERCISE_NAME);
+      } catch (error) {
+        console.error(error);
+        alert(error.message);
+      }
     }
   };
 
@@ -57,7 +76,7 @@ const EditWorkoutPage: React.FC<EditWorkoutPageProps> = ({ navigation }) => {
       <ExerciseBlock
         exercise={item}
         editing={editingExercise}
-        update={updateExercise}
+        update={updateOrInsertExercise}
         onPress={navigateToExercise}
       />
     );

--- a/src/screens/MyWorkouts/MyWorkouts.tsx
+++ b/src/screens/MyWorkouts/MyWorkouts.tsx
@@ -6,17 +6,17 @@ import AddButton from '../../components/AddButton';
 import WorkoutBlock from '../../components/WorkoutBlock';
 import { useAuth } from '../../contexts/AuthProvider';
 import { useMyWorkouts } from '../../hooks/useMyWorkouts';
-import { createEditableWorkout, updateEditableWorkout } from '../../hooks/useEditableWorkout';
-import { EditableWorkout } from '../../types/EditableWorkout';
-import useSelectedWorkout from '../../hooks/useSelectedWorkout';
+import { createEditableWorkout, updateEditableWorkout } from '../../utils/workouts';
+import useBreadcrumbHistory from '../../hooks/useBreadcrumbHistory';
+import { EditableWorkout } from '../../types';
 
 export type MyWorkoutsProps = NativeStackScreenProps<NavigatorParamList, 'MyWorkouts'>;
 
 const MyWorkouts: React.FC<MyWorkoutsProps> = ({ navigation }) => {
   const { session } = useAuth();
-  const { workouts, refresh: refreshWorkouts } = useMyWorkouts(session);
+  const { workouts, fetch: refreshWorkouts } = useMyWorkouts(session);
   const [editingWorkout, setEditingWorkout] = useState<string | undefined>(undefined);
-  const [setSelectedWorkout] = useSelectedWorkout((state) => [state.setWorkout]);
+  const [setSelectedWorkout] = useBreadcrumbHistory((state) => [state.setWorkout]);
 
   const addWorkoutBlock = async () => {
     const workout = await createEditableWorkout(session);
@@ -25,7 +25,7 @@ const MyWorkouts: React.FC<MyWorkoutsProps> = ({ navigation }) => {
   };
 
   const updateWorkout = async (payload) => {
-    await updateEditableWorkout(payload);
+    await updateEditableWorkout(payload.id, payload);
     setEditingWorkout(undefined);
     if (refreshWorkouts) await refreshWorkouts();
   };

--- a/src/types/EditableWorkout.ts
+++ b/src/types/EditableWorkout.ts
@@ -1,7 +1,0 @@
-import { Exercise } from './Exercise';
-export interface EditableWorkout {
-  id: string;
-  name?: string;
-  created_by?: string;
-  exercises?: Array<Exercise>;
-}

--- a/src/types/Exercise.ts
+++ b/src/types/Exercise.ts
@@ -1,8 +1,0 @@
-import { Set } from '../screens/EditExercise/EditExercisePage';
-
-export interface Exercise {
-  name: string;
-  sets: Set[];
-}
-
-export const PLACEHOLDER_EXERCISE_NAME = 'placeholder';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,63 @@
+export type Set = {
+  key: number;
+  reps: string;
+  rpe: string; // Rating of Perceived Exertion
+  orm: string; // One Rep Max
+};
+
+export interface Exercise {
+  name: string;
+  sets: Set[];
+}
+
+export interface EditableWorkout {
+  id: string;
+  name?: string;
+  created_by?: string;
+  exercises?: Exercise[];
+}
+
+export interface ConsumableSet {
+  reps?: number;
+  weight?: number;
+  bodyweight?: boolean;
+  ref: Set; // The reference set, i.e. the prescribed reps, rpe, and %orm
+}
+
+export interface ConsumableExercise {
+  name: string;
+  sets: ConsumableSet[];
+}
+
+/**
+ * Example ConsumableWorkout with one exercise and one set
+ * {
+ *  id: 'xC12ilA201P'
+ *  name: 'Back and Bis',
+ *  created_by: 'uid12345',
+ *  exercises: [
+ *    {
+ *      name: 'Pullups',
+ *      sets: [
+ *        reps: 0,
+ *        weight: 0,
+ *        bodyweight: false,
+ *        ref: {
+ *          key: 0,
+ *          reps: 12,
+ *          rpe: 7,
+ *          orm: 75
+ *        }
+ *      ]
+ *    }
+ *  ]
+ * }
+ */
+export interface ConsumableWorkout {
+  id: string;
+  name?: string;
+  created_by?: string;
+  exercises: ConsumableExercise[];
+}
+
+export const PLACEHOLDER_EXERCISE_NAME = 'placeholder';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,8 @@ export interface ConsumableWorkout {
   id: string;
   name?: string;
   created_by?: string;
+  started_at?: Date;
+  ended_at?: Date;
   exercises: ConsumableExercise[];
 }
 

--- a/src/utils/workouts.ts
+++ b/src/utils/workouts.ts
@@ -1,0 +1,183 @@
+import { supabase } from './supabaseClient';
+import { Session, User } from '@supabase/supabase-js';
+import { EditableWorkout, Exercise } from '../types';
+import { DuplicateExerciseError, ExerciseNotFoundError, UnauthenticatedError } from '../errors';
+
+/**
+ *
+ * @param userId Id of the current user
+ * @returns An array of Editable Workouts
+ */
+export const getEditableWorkoutsByUserId = async (userId: string): Promise<EditableWorkout[]> => {
+  const { data, error } = await supabase
+    .from('workouts')
+    .select(`id, name`)
+    .eq('created_by', userId);
+  if (error) throw error;
+  return data;
+};
+
+/**
+ * Create a new EditableWorkout in supabase and get the auto generated id
+ * @param session Current session -- from the AuthProvider context
+ * @returns An `EditableWorkout`
+ * @throws `PostgresError` or `UnauthenticatedError`
+ */
+export const createEditableWorkout = async (
+  session: Session | null
+): Promise<EditableWorkout | undefined> => {
+  if (session === undefined || session === null)
+    throw new UnauthenticatedError('Cannot create a workout with no active user session.');
+
+  const user: User = session.user;
+
+  const { data, error } = await supabase
+    .from('workouts')
+    .insert({ name: '', created_by: user.id })
+    .select(`id`)
+    .single();
+  if (error) throw error;
+
+  return data as EditableWorkout;
+};
+
+/**
+ * Returns an EditableWorkout from supabase
+ * @param workoutId Id of the EditableWorkout
+ * @returns An `EditableWorkout`
+ * @throws `PostgresError`
+ */
+export const getEditableWorkout = async (workoutId: string): Promise<EditableWorkout> => {
+  const { data, error } = await supabase.from('workouts').select('*').eq('id', workoutId).single();
+  if (error) throw error;
+
+  return data as EditableWorkout;
+};
+
+/**
+ * Delete an EditableWorkout by id in supabase
+ * @param workoutId Id of the EditableWorkout
+ * @throws `PostgresError`
+ */
+export const deleteEditableWorkout = async (workoutId: string) => {
+  const { error } = await supabase.from('workouts').delete().eq('id', workoutId);
+  if (error) throw error;
+};
+
+/**
+ * Updates an EditableWorkout in supabase
+ * @param workoutId The id of the EditableWorkout to update
+ * @param payload The updates to apply to the EditableWorkout
+ * @throws `PostgresError`
+ */
+export const updateEditableWorkout = async (workoutId: string, payload: EditableWorkout) => {
+  const { error } = await supabase.from('workouts').update(payload).eq('id', workoutId);
+  if (error) throw error;
+};
+
+/**
+ * Returns the exercises in an EditableWorkout from supabase
+ * @param workoutId The id of the EditableWorkout
+ * @returns Array of exercises
+ * @throws `PostgresError`
+ */
+export const getExercisesInWorkout = async (workoutId: string): Promise<Exercise[]> => {
+  const { error, data } = await supabase
+    .from('workouts')
+    .select('exercises')
+    .eq('id', workoutId)
+    .single();
+
+  if (error) throw error;
+
+  const exercises: Array<Exercise> = data.exercises;
+  return exercises;
+};
+
+/**
+ *  Returns a single exercise from an EditableWorkout in supabase by name
+ * @param exerciseName
+ * @param workoutId
+ * @returns An `Exercise`
+ * @throws `ExerciseNotFoundError`
+ */
+export const getExerciseInWorkout = async (
+  exerciseName: string,
+  workoutId: string
+): Promise<Exercise> => {
+  const exercises: Array<Exercise> = await getExercisesInWorkout(workoutId);
+
+  for (let i = 0; i < exercises.length; i++) {
+    if (exercises[i].name === exerciseName) {
+      return exercises[i];
+    }
+  }
+
+  throw new ExerciseNotFoundError('Cannot find exercise in current workout');
+};
+
+/**
+ * Returns an array of exercises with the new exercise updates
+ * @param exercise New `Exercise` object
+ * @throws `PostgresError` or `ExerciseNotFoundError`
+ */
+export const updateExerciseInWorkout = async (exercise: Exercise, workoutId: string) => {
+  const exercises: Array<Exercise> = await getExercisesInWorkout(workoutId);
+
+  let found = false;
+  for (let i = 0; i < exercises.length; i++) {
+    if (exercises[i].name === exercise.name) {
+      exercises[i] = exercise;
+      found = true;
+      break;
+    }
+  }
+  if (!found) throw new ExerciseNotFoundError(`No exercise found with name ${exercise.name}`);
+
+  const { error } = await supabase.from('workouts').update({ exercises }).eq('id', workoutId);
+  if (error) throw error;
+};
+
+/**
+ * Inserts an exercise into an EditableWorkout in supabase
+ * @param exerciseName New exercise name to insert into the workout
+ * @param workoutId The id of the `EditableWorkout`
+ * @throws `PostgresError` or `DuplicateExerciseError
+ */
+export const insertExerciseIntoWorkout = async (exerciseName: string, workoutId: string) => {
+  const exercises: Array<Exercise> = await getExercisesInWorkout(workoutId);
+
+  const hasExerciseAlready = exercises.find((e) => e.name === exerciseName);
+
+  if (hasExerciseAlready)
+    throw new DuplicateExerciseError('Cannot add the same exercise to a workout');
+
+  const exerciseToInsert = {
+    name: exerciseName,
+    sets: [],
+  } as Exercise;
+
+  exercises.push(exerciseToInsert);
+
+  const { error } = await supabase.from('workouts').update({ exercises }).eq('id', workoutId);
+  if (error) throw error;
+};
+
+/**
+ * Deletes an exercise in an editable workout in supabase
+ * @param exerciseName name of the exercise to delete
+ * @param workoutId Id of the EditableWorkout
+ * @throws `PostgresError` or `ExerciseNotFoundError`
+ */
+export const deleteExerciseInWorkout = async (exerciseName: string, workoutId: string) => {
+  const exercises: Array<Exercise> = await getExercisesInWorkout(workoutId);
+
+  const index = exercises.findIndex((e) => e.name === exerciseName);
+
+  if (index < 0) throw new ExerciseNotFoundError(`No exercise found with name ${exerciseName}`);
+
+  exercises.splice(index, 1);
+
+  const { error } = await supabase.from('workouts').update({ exercises }).eq('id', workoutId);
+  if (error) throw error;
+};


### PR DESCRIPTION
# Notes

### Refactoring
- Moves the workouts database functionality into /utils/workouts.ts
- Moves all types into /types
- Creates and puts custom Error types into /errors
- Changes `useEditableWorkout `hook to allow for non-realtime use
- Moves duplicated rendering logic for workout and exercise blocks into a `Block` component

### Documentation
- Documents all util database functions
- Adds new `ConsumableWorkout` type and gives example

### Minor Fixes
- Adds white background color where applicable for consistent look
- Fixes 'pre' -> 'rpe' for sets in exercises

# Done Criteria

- [x] No errors while navigating UI
- [X] Document utils and api functions

# Testing

Hand tested: Clicked through UI, no errors
