### PR TITLE
add checks for empty graph data

### DIFF
--- a/src/components/analytics/AnalyticsGraph.tsx
+++ b/src/components/analytics/AnalyticsGraph.tsx
@@ -51,6 +51,13 @@ const ExerciseLine: React.ForwardRefExoticComponent<ExerciseLineProps & LineProp
         }
       }, [metricType, timeframe, analyticsSelector, selectorIsSet]);
 
+      if (
+        analytics?.graphData === null ||
+        analytics?.graphData === undefined ||
+        analytics.graphData.length == 0
+      )
+        return null;
+
       return <Line data={analytics?.graphData || [{ x: 0, y: 0 }]} {...rest} ref={ref} />;
     }
   );


### PR DESCRIPTION
# Notes

Solves issue where app crashes because no data exists for selected exercises to pass to analytics graph.

# Done Criteria

- [X] No errors while navigating UI
- [X] Document utils and api functions

# Testing

Hand tested: Clicked through UI, no errors
